### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/petender/dependabot-demo/security/code-scanning/2](https://github.com/petender/dependabot-demo/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow interacts with repository contents (e.g., via `actions/checkout@v1`), the minimal required permission is `contents: read`. This ensures the workflow has only the access it needs to function correctly while adhering to the principle of least privilege.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs unless overridden by job-specific permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
